### PR TITLE
fix failing tests

### DIFF
--- a/tests/DataMapper/DataMapperTest.php
+++ b/tests/DataMapper/DataMapperTest.php
@@ -18,6 +18,7 @@ use PHPUnit\Framework\TestCase;
 use SensioLabs\RichModelForms\Extension\RichModelFormsTypeExtension;
 use SensioLabs\RichModelForms\Tests\Fixtures\Form\CancelSubscriptionType;
 use SensioLabs\RichModelForms\Tests\Fixtures\Form\ChangeProductStockType;
+use SensioLabs\RichModelForms\Tests\Fixtures\Form\ChangeProductStockTypeExtension;
 use SensioLabs\RichModelForms\Tests\Fixtures\Form\PauseSubscriptionType;
 use SensioLabs\RichModelForms\Tests\Fixtures\Form\ProductDataType;
 use SensioLabs\RichModelForms\Tests\Fixtures\Form\TypeMismatchPriceChangeType;
@@ -221,7 +222,7 @@ class DataMapperTest extends TestCase
 
     public function testMismatchingArgumentTypesWillBeConvertedToErrors()
     {
-        $form = $this->createForm(ChangeProductStockType::class, new Product('A fancy product', Price::fromAmount(500)));
+        $form = $this->createForm(ChangeProductStockType::class, new Product('A fancy product', Price::fromAmount(500)), [], [new ChangeProductStockTypeExtension(PropertyAccess::createPropertyAccessor())]);
         $form->submit([
             'stock' => '',
         ]);
@@ -273,17 +274,18 @@ class DataMapperTest extends TestCase
         $this->assertSame('The product name must have a length of 10 characters or more.', $form->get('name')->getErrors()[0]->getCause()->getMessage());
     }
 
-    private function createFormBuilder(string $type, $data = null, array $options = []): FormBuilderInterface
+    private function createFormBuilder(string $type, $data = null, array $options = [], array $additionalExtensions = []): FormBuilderInterface
     {
         $formFactory = (new FormFactoryBuilder())
             ->addTypeExtension(new RichModelFormsTypeExtension(PropertyAccess::createPropertyAccessor()))
+            ->addTypeExtensions($additionalExtensions)
             ->getFormFactory();
 
         return $formFactory->createBuilder($type, $data, $options);
     }
 
-    private function createForm(string $type, $data, array $options = []): FormInterface
+    private function createForm(string $type, $data, array $options = [], array $additionalExtensions = []): FormInterface
     {
-        return $this->createFormBuilder($type, $data, $options)->getForm();
+        return $this->createFormBuilder($type, $data, $options, $additionalExtensions)->getForm();
     }
 }

--- a/tests/Fixtures/Form/ChangeProductStockType.php
+++ b/tests/Fixtures/Form/ChangeProductStockType.php
@@ -15,6 +15,7 @@ declare(strict_types = 1);
 namespace SensioLabs\RichModelForms\Tests\Fixtures\Form;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\DataMapperInterface;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\FormBuilderInterface;
 
@@ -23,10 +24,26 @@ class ChangeProductStockType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
-            ->add('stock', IntegerType::class, [
-                'read_property_path' => 'currentStock',
-                'write_property_path' => 'allocateStock',
-            ])
+            ->add('stock', IntegerType::class)
+            ->setDataMapper(new class implements DataMapperInterface {
+                public function mapDataToForms($data, $forms): void
+                {
+                    foreach ($forms as $form) {
+                        if ($form->getConfig()->getName() === 'stock') {
+                            $form->setData($data->currentStock());
+                        }
+                    }
+                }
+
+                public function mapFormsToData($forms, &$data): void
+                {
+                    foreach ($forms as $form) {
+                        if ($form->getConfig()->getName() === 'stock') {
+                            $data->allocateStock($form->getData());
+                        }
+                    }
+                }
+            });
         ;
     }
 }

--- a/tests/Fixtures/Form/ChangeProductStockTypeExtension.php
+++ b/tests/Fixtures/Form/ChangeProductStockTypeExtension.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the RichModelFormsBundle package.
+ *
+ * (c) Christian Flothmann <christian.flothmann@sensiolabs.de>
+ * (c) Christopher Hertel <christopher.hertel@sensiolabs.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types = 1);
+
+namespace SensioLabs\RichModelForms\Tests\Fixtures\Form;
+
+use SensioLabs\RichModelForms\DataMapper\DataMapper;
+use SensioLabs\RichModelForms\DataMapper\ExceptionHandler\ArgumentTypeMismatchExceptionHandler;
+use SensioLabs\RichModelForms\DataMapper\ExceptionHandler\ChainExceptionHandler;
+use SensioLabs\RichModelForms\DataMapper\ExceptionHandler\FallbackExceptionHandler;
+use Symfony\Component\Form\AbstractTypeExtension;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\PropertyAccess\PropertyAccess;
+
+final class ChangeProductStockTypeExtension extends AbstractTypeExtension
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $exceptionHandler = new ChainExceptionHandler([
+            new ArgumentTypeMismatchExceptionHandler(),
+            new FallbackExceptionHandler(),
+        ]);
+
+        $builder->setDataMapper(new DataMapper($builder->getDataMapper(), PropertyAccess::createPropertyAccessor(), $exceptionHandler));
+    }
+
+    public function getExtendedType(): string
+    {
+        return ChangeProductStockType::class;
+    }
+}


### PR DESCRIPTION
After https://github.com/symfony/symfony/pull/28220 had been merged
type errors were caught as expected by the PropertyAccess component.
This means that they were transformed into InvalidArgumentException
instances and were never passed as type errors to the
ArgumentTypeMismatchExceptionHandler.