### PR TITLE
harmonize closure property paths

### DIFF
--- a/src/DataMapper/DataMapper.php
+++ b/src/DataMapper/DataMapper.php
@@ -20,7 +20,6 @@ use SensioLabs\RichModelForms\DataMapper\ExceptionHandler\ExceptionHandlerRegist
 use SensioLabs\RichModelForms\DataMapper\ExceptionHandler\GenericExceptionHandler;
 use Symfony\Component\Form\DataMapperInterface;
 use Symfony\Component\Form\Exception\UnexpectedTypeException;
-use Symfony\Component\Form\FormError;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 
@@ -101,24 +100,7 @@ final class DataMapper implements DataMapperInterface
                 if ($forwardToWrappedDataMapper) {
                     $this->dataMapper->mapFormsToData([$form], $data);
                 } elseif ($writePropertyPath instanceof \Closure) {
-                    if (null !== $writePropertyPath = $writePropertyPath($form->getData())) {
-                        // The property accessor expects the method to accept exactly one argument for write access. Since
-                        // our write option here is chosen based on the submitted value we do not need to (and explicitly do
-                        // not want to) pass and value we use the property accessor's read operation which will call the
-                        // method without any argument.
-                        $this->propertyAccessor->getValue($data, $writePropertyPath);
-                    } else {
-                        $messageTemplate = $form->getConfig()->getOption('invalid_message') ?? 'This value is not valid.';
-                        $parameters = $form->getConfig()->getOption('invalid_message_parameters') ?? [];
-
-                        if (null !== $this->translator) {
-                            $message = $this->translator->trans($messageTemplate, $parameters, $this->translationDomain);
-                        } else {
-                            $message = strtr($messageTemplate, $parameters);
-                        }
-
-                        $form->addError(new FormError($message, $messageTemplate, $parameters));
-                    }
+                    $writePropertyPath($data, $form->getData());
                 } else {
                     $this->propertyAccessor->setValue($data, $writePropertyPath, $form->getData());
                 }

--- a/tests/DataMapper/DataMapperTest.php
+++ b/tests/DataMapper/DataMapperTest.php
@@ -232,7 +232,7 @@ class DataMapperTest extends TestCase
         $this->assertFalse($subscription->isSuspended());
     }
 
-    public function testSubmittingValuesNotResolvingToWritePropertyPathsInvalidateTheForm(): void
+    public function testSubmittingValuesTriggeringExceptionsInClosureWritePropertyPathsInvalidateForms(): void
     {
         $form = $this->createForm(PauseSubscriptionType::class, new Subscription(new \DateTimeImmutable()));
         $form->submit([

--- a/tests/Fixtures/Form/PauseSubscriptionType.php
+++ b/tests/Fixtures/Form/PauseSubscriptionType.php
@@ -31,13 +31,13 @@ class PauseSubscriptionType extends AbstractType
                     'paused' => false,
                 ],
                 'read_property_path' => 'isSuspended',
-                'write_property_path' => function ($data) {
-                    if (true === $data) {
-                        return 'reactivate';
-                    }
-
-                    if (false === $data) {
-                        return 'suspend';
+                'write_property_path' => function (Subscription $subscription, $submittedData): void {
+                    if (true === $submittedData) {
+                        $subscription->reactivate();
+                    } elseif (false === $submittedData) {
+                        $subscription->suspend();
+                    } else {
+                        throw new \LogicException('This value is not valid.');
                     }
                 },
             ])


### PR DESCRIPTION
In #37, we introduced the possibility to define the read property path
as a closure. This was already possible for write operations too. The
difference was that closures defined for the write property path did
not call any methods of the model themselves, but only returned another
property path.

This is changed now and the configured closures need to call model
methods just like when reading data from the model. Wrongly submitted
data must now be indicated by throwing exceptions from inside the
anonymous functions (or by forwarding them from the model).